### PR TITLE
Feature: Define module name on command line

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -77,6 +77,7 @@ program
     .option('-k --testsLists <tests>', 'tests lists')
     .option('--notificationTitle <title>', 'Custom Notification Title for Slack')
     .option('-b --bypass <title>', 'Bypass Deployment Info Update with the latest commit SHA')
+    .option('-o --module <name>', 'modulename to set the commit SHA after the deployment process. Default: All', 'All')
     .action((command) => {
         logger.debug(process.env);
         logger.info('command.artifactpath', command.artifactpath);
@@ -139,6 +140,7 @@ program
     .option('-b --bypass <title>', 'Bypass Deployment Info Update with the latest commit SHA')
     .option('-l --testlevel <testLevel>', '(NoTestRun|RunSpecifiedTests|RunLocalTests|RunAllTestsInOrg) deployment testing level.')
     .option('-k --testsLists <tests>', 'tests lists')
+    .option('-o --module <name>', 'modulename to set the commit SHA after the deployment process. Default: All', 'All')
     .action((command) => {
         logger.debug(process.env);
         logger.info('command.artifactpath', command.artifactpath);

--- a/src/services/deploymentService.js
+++ b/src/services/deploymentService.js
@@ -701,15 +701,15 @@ const deploymentProcessor = {
             // the module name logic will be refined to support modular deployment
             const gitTag = 'DEPLOYED';
             return alias
-            ? deploymentInfoService.updateDeploymentInfo('All', shortSHA, gitTag, null, alias, deploymentRes)
-            : deploymentInfoService.updateDeploymentInfo('All', shortSHA, gitTag, connection, null, deploymentRes);
+            ? deploymentInfoService.updateDeploymentInfo(command.module, shortSHA, gitTag, null, alias, deploymentRes)
+            : deploymentInfoService.updateDeploymentInfo(command.module, shortSHA, gitTag, connection, null, deploymentRes);
 
         } else if(!this.isNotValidation(command)){
             // Update the Deployment Info with the deployment id, without updating the SHA
             const gitTag = 'VALIDATED';
             return alias
-            ? deploymentInfoService.updateDeploymentInfo('All', shortSHA, gitTag, null, alias, deploymentRes)
-            : deploymentInfoService.updateDeploymentInfo('All', shortSHA, gitTag, connection, null, deploymentRes);
+            ? deploymentInfoService.updateDeploymentInfo(command.module, shortSHA, gitTag, null, alias, deploymentRes)
+            : deploymentInfoService.updateDeploymentInfo(command.module, shortSHA, gitTag, connection, null, deploymentRes);
         }
         else {
             logger.info('Not Updating the deployment Info in the target org, as it is a bypass');


### PR DESCRIPTION
Create a new command-line argument to define the module name.

On the previous version, the module name was fixed as 'All' not allowing the developer to specify what will be the module name will be used to store the deployment commit hash.

It was added a new option -o to define what will be the module name. The module name will be 'All' if no argument is specified.
